### PR TITLE
Make Oneko Click-through

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,0 +1,5 @@
+oneko: oneko.c oneko.h bitmaps/* bitmasks/*
+	cc -DSHAPE -O2 oneko.c -o oneko -lX11 -lXext -lXfixes -lm
+
+clean:
+	rm -f oneko

--- a/oneko.c
+++ b/oneko.c
@@ -270,6 +270,19 @@ Animation       AnimationPattern[][2] =
 static void NullFunction();
 
 /*
+ * Enable click-through for specified window
+ */
+
+#ifdef SHAPE
+void SetWindowClickThrough(Display *dpy, Window win) {
+    XRectangle rect;
+    XserverRegion region = XFixesCreateRegion(dpy, &rect, 1);
+    XFixesSetWindowShapeRegion(dpy, win, ShapeInput, 0, 0, region);
+    XFixesDestroyRegion(dpy, region);
+}
+#endif
+
+/*
  *      Scales the bitmap, returning a freshly malloc()'d copy which it is the
  *      caller's responsibility to free.
  */
@@ -763,6 +776,7 @@ InitScreen(DisplayName)
                             BITMAP_WIDTH * ScaleFactor, BITMAP_HEIGHT * ScaleFactor,
                             0, theDepth, InputOutput, CopyFromParent,
                             theWindowMask, &theWindowAttributes);
+  SetWindowClickThrough(theDisplay, theWindow);
 
   if (WindowName == NULL) WindowName = ProgramName;
   XStoreName(theDisplay, theWindow, WindowName);

--- a/oneko.c
+++ b/oneko.c
@@ -43,7 +43,7 @@ typedef struct _AnimalDefaults {
   int cursor_width,cursor_height,cursor_x_hot,cursor_y_hot;
 } AnimalDefaultsData;
 
-AnimalDefaultsData AnimalDefaultsDataTable[] = 
+AnimalDefaultsData AnimalDefaultsDataTable[] =
 {
   { "neko", 13, 6, 32, 32, 125000L, 0, 0, mouse_cursor_bits,mouse_cursor_mask_bits,
       mouse_cursor_width,mouse_cursor_height, mouse_cursor_x_hot,mouse_cursor_y_hot },
@@ -511,7 +511,7 @@ MakeMouseCursor()
 
     theCursorSource
         = XCreateBitmapFromData(theDisplay, theRoot,
-                                AnimalDefaultsDataTable[NekoMoyou].cursor, 
+                                AnimalDefaultsDataTable[NekoMoyou].cursor,
                                 AnimalDefaultsDataTable[NekoMoyou].cursor_width,
                                 AnimalDefaultsDataTable[NekoMoyou].cursor_height);
 
@@ -613,7 +613,7 @@ Window Select_Window(dpy)
         buttons--;
        break;
     }
-  } 
+  }
 
   XUngrabPointer(dpy, CurrentTime);      /* Done with pointer */
 
@@ -769,7 +769,7 @@ InitScreen(DisplayName)
 
   InitBitmapAndGCs();
 
-  XSelectInput(theDisplay, theWindow, 
+  XSelectInput(theDisplay, theWindow,
                ExposureMask|VisibilityChangeMask|KeyPressMask);
 
   XFlush(theDisplay);
@@ -1029,7 +1029,7 @@ IsNekoMoveStart()
 {
     if ((PrevMouseX >= MouseX - IdleSpace
          && PrevMouseX <= MouseX + IdleSpace) &&
-         (PrevMouseY >= MouseY - IdleSpace 
+         (PrevMouseY >= MouseY - IdleSpace
          && PrevMouseY <= MouseY + IdleSpace) &&
         (PrevTarget == theTarget)) {
         return(False);
@@ -1106,9 +1106,9 @@ CalcDxDy()
         RestoreCursor();
       }
 
-      if (theTargetAttributes.x+theTargetAttributes.width > 0 
+      if (theTargetAttributes.x+theTargetAttributes.width > 0
           && theTargetAttributes.x < (int)WindowWidth
-          && theTargetAttributes.y+theTargetAttributes.height > 0 
+          && theTargetAttributes.y+theTargetAttributes.height > 0
           && theTargetAttributes.y < (int)WindowHeight
           && theTargetAttributes.map_state == IsViewable) {
         if (ToFocus) {
@@ -1118,14 +1118,14 @@ CalcDxDy()
                    -BITMAP_WIDTH*ScaleFactor/2)
             LargeX = (double)(theTargetAttributes.x + theTargetAttributes.width
                               + XOffset - NekoX - BITMAP_WIDTH * ScaleFactor);
-          else 
+          else
             LargeX = (double)(MouseX - NekoX - BITMAP_WIDTH * ScaleFactor / 2);
 
           LargeY = (double)(theTargetAttributes.y
                             + YOffset - NekoY - BITMAP_HEIGHT * ScaleFactor);
         }
         else {
-          MouseX = theTargetAttributes.x 
+          MouseX = theTargetAttributes.x
             + theTargetAttributes.width / 2 + XOffset;
           MouseY = theTargetAttributes.y + YOffset;
           LargeX = (double)(MouseX - NekoX - BITMAP_WIDTH * ScaleFactor / 2);
@@ -1197,7 +1197,7 @@ NekoThinkDraw()
             SetNekoState(NEKO_U_TOGI);
         } else if ((NekoMoveDy > 0
                     && NekoY >= WindowHeight - BITMAP_HEIGHT * ScaleFactor)
-                   || (ToFocus && theTarget != None 
+                   || (ToFocus && theTarget != None
                        &&  NekoY < MouseY - BITMAP_HEIGHT * ScaleFactor)){
             SetNekoState(NEKO_D_TOGI);
         } else {
@@ -1352,7 +1352,7 @@ ProcessEvent()
             if (RaiseWindowDelay==0) {
               XRaiseWindow(theDisplay,theWindow);
               RaiseWindowDelay=DEFAULT_RAISE_WAIT;
-            } 
+            }
         default:
             /* Unknown Event */
             break;

--- a/oneko.h
+++ b/oneko.h
@@ -11,6 +11,7 @@
 #include <X11/Xlib.h>
 #include <X11/Xutil.h>
 #include <X11/extensions/shape.h>
+#include <X11/extensions/Xfixes.h>
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
With a window manager that uses the "Focus Follows Mouse" mode, oneko is focused every time it reaches the mouse. If focused, oneko will consume all mouse events, which is sometimes annoying. For example, if I click a button and oneko is laying under the mouse, this click event will be sent to oneko but not the button. I have to first move the mouse to somewhere to drive away oneko, and try to click the button before it comes back.

This patch tries to solve this problem by making oneko click-through. All events that oneko received will be simply passed through. This feature depends on X11 `XFixed` extension, which means we need to add `-lXfixed` to our compile options.